### PR TITLE
fix: ConcurrentModificationException for lists with >1 entries

### DIFF
--- a/src/main/kotlin/settingdust/registryblocker/Entrypoint.kt
+++ b/src/main/kotlin/settingdust/registryblocker/Entrypoint.kt
@@ -43,9 +43,8 @@ fun init() {}
 fun <T> MutableMap<T, RegistryEntry.Reference<T>>.removeIntrusiveValues(
     blocked: Map<RegistryKey<T>, T>
 ) {
-    for ((key, _) in this) {
-        if (blocked.containsValue(key)) {
-            remove(key)
-        }
+    val blockedValues: Set<T> = blocked.values.toSet()
+    entries.removeIf { (key, _) ->
+        key in blockedValues
     }
 }


### PR DESCRIPTION
The Iterator for the Map implicitly produced by the for-loop doesn't know about the Map's modifications during the for loop, and results in a ConcurrentModificationError.

Warning though: I have not tested this fix yet! Mainly because I *literally* cannot get it to load on Fabric on any of the versions listed. I even tried with Quilt (although I have never used that loader before, so bare that in mind...), and still got the same error. I have no clue what is going on with it, but I've only had success when using version 0.3.0. 

That being said, it is a small and obvious fix so I don't see it resulting in any issues, though I wish I could test and use it...

Here is the crash I get when running it as well...


Mods/Loaders Used: (I've also tried Minecraft 1.21.1 Fabric with a similar set-up)
Minecraft 1.20.1
Fabric Loader 0.16.14
Fabric API 0.92.6+1.20.1
RegistryBlocker 0.5.3
Fabric Language Kotlin 1.13.6+kotlin.2.2.20

```
org.quiltmc.loader.impl.FormattedException: java.lang.RuntimeException: Could not execute entrypoint stage 'preLaunch' due to errors, provided by 'registry-blocker' at 'settingdust.registryblocker.EntrypointKt::init'!
	at org.quiltmc.loader.impl.QuiltLoaderImpl.invokePreLaunch(QuiltLoaderImpl.java:1244)
	at org.quiltmc.loader.impl.launch.knot.Knot.init(Knot.java:178)
	at org.quiltmc.loader.impl.launch.knot.Knot.launch(Knot.java:79)
	at org.quiltmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:28)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
Caused by: java.lang.RuntimeException: Could not execute entrypoint stage 'preLaunch' due to errors, provided by 'registry-blocker' at 'settingdust.registryblocker.EntrypointKt::init'!
	at org.quiltmc.loader.impl.entrypoint.EntrypointUtils.lambda$invoke0$2(EntrypointUtils.java:66)
	at org.quiltmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:34)
	at org.quiltmc.loader.impl.entrypoint.EntrypointUtils.invoke0(EntrypointUtils.java:64)
	at org.quiltmc.loader.impl.entrypoint.EntrypointUtils.invokeContainer(EntrypointUtils.java:49)
	at org.quiltmc.loader.impl.entrypoint.EntrypointUtils.invoke(EntrypointUtils.java:36)
	at org.quiltmc.loader.impl.QuiltLoaderImpl.invokePreLaunch(QuiltLoaderImpl.java:1242)
	... 6 more
Caused by: org.quiltmc.loader.impl.entrypoint.QuiltEntrypointException: Exception while loading entries for entrypoint 'preLaunch' provided by 'registry-blocker'
	at org.quiltmc.loader.impl.entrypoint.EntrypointStorage.lambda$getEntrypointContainers$1(EntrypointStorage.java:241)
	at org.quiltmc.loader.impl.entrypoint.EntrypointContainerImpl.getEntrypoint(EntrypointContainerImpl.java:73)
	at org.quiltmc.loader.impl.entrypoint.EntrypointUtils.lambda$invoke$0(EntrypointUtils.java:36)
	at org.quiltmc.loader.impl.entrypoint.EntrypointUtils.invoke0(EntrypointUtils.java:62)
	... 9 more
Caused by: java.lang.NoClassDefFoundError: org/quiltmc/qkl/library/serialization/options/CodecOptionsBuilder
	at settingdust.registryblocker.EntrypointKt.<clinit>(Entrypoint.kt:37)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:421)
	at java.base/java.lang.Class.forName(Class.java:412)
	at net.fabricmc.language.kotlin.KotlinAdapter.create(KotlinAdapter.kt:40)
	at net.fabricmc.loader.api.LanguageAdapter.create(LanguageAdapter.java:124)
	at org.quiltmc.loader.impl.entrypoint.EntrypointStorage$NewEntry.getOrCreate(EntrypointStorage.java:123)
	at org.quiltmc.loader.impl.entrypoint.EntrypointStorage.lambda$getEntrypointContainers$1(EntrypointStorage.java:239)
	... 12 more
Caused by: java.lang.ClassNotFoundException: org.quiltmc.qkl.library.serialization.options.CodecOptionsBuilder
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at org.quiltmc.loader.impl.launch.knot.KnotClassDelegate.loadClassOnly(KnotClassDelegate.java:204)
	at org.quiltmc.loader.impl.launch.knot.KnotClassDelegate.loadClass(KnotClassDelegate.java:176)
	at org.quiltmc.loader.impl.launch.knot.KnotClassLoader.loadClass(KnotClassLoader.java:243)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 20 more
	```   